### PR TITLE
Listen on IPv6 if called with -6

### DIFF
--- a/Params.py
+++ b/Params.py
@@ -8,6 +8,7 @@ ROOT = os.getcwd() + os.sep
 VERBOSE = 0
 TIMEOUT = 15
 FAMILY = socket.AF_INET
+LISTENFAMILY = socket.AF_INET
 FLAT = False
 STATIC = False
 ONLINE = True
@@ -61,6 +62,7 @@ for _arg in _args:
       sys.exit( 'Error: %s requires a positive numerical argument' % _arg )
   elif _arg in ( '-6', '--ipv6' ):
     FAMILY = socket.AF_UNSPEC
+    LISTENFAMILY = socket.AF_INET6
   elif _arg == '--flat':
     FLAT = True
   elif _arg == '--static':

--- a/Protocol.py
+++ b/Protocol.py
@@ -13,7 +13,7 @@ def connect( addr ):
 
   family, socktype, proto, canonname, sockaddr = DNSCache[ addr ][ 0 ]
 
-  print 'Connecting to %s:%i' % sockaddr
+  print 'Connecting to [%s]:%i' % sockaddr[0:2]
   sock = socket.socket( family, socktype, proto )
   sock.setblocking( 0 )
   sock.connect_ex( sockaddr )

--- a/fiber.py
+++ b/fiber.py
@@ -176,10 +176,10 @@ def fork( output ):
   os.dup2( nul.fileno(), sys.stdin.fileno()  )
 
 
-def spawn( generator, port, debug, log ):
+def spawn( generator, port, debug, log, listenfamily ):
 
   try:
-    listener = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
+    listener = socket.socket( listenfamily, socket.SOCK_STREAM )
     listener.setblocking( 0 )
     listener.setsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR, listener.getsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR ) | 1 )
     listener.bind( ( '', port ) )

--- a/http-replicator
+++ b/http-replicator
@@ -9,7 +9,7 @@ DOWNLOADS = weakref.WeakValueDictionary()
 
 def Replicator( client, address ):
 
-  print 'Accepted request from %s:%i' % address
+  print 'Accepted request from [%s]:%i' % address[0:2]
 
   request = Request.HttpRequest( client )
   for state in request:
@@ -59,4 +59,4 @@ def Replicator( client, address ):
   print 'Transaction successfully completed'
 
 
-fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG )
+fiber.spawn( Replicator, Params.PORT, Params.DEBUG, Params.LOG, Params.LISTENFAMILY )


### PR DESCRIPTION
I found that http-replicator didn't listen on IPv6 even if called with
-6 (that apparently only makes it use IPv6 on outgoing
connections). This patch changes the call to socket.socket to use
AF_INET6 if -6 is used.  I also had to fix the message printed for
accepted connections.

I'm not certain that this is the best way to do it, but it works for
me. ;)
